### PR TITLE
C++: add interned trace resolver helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,7 @@ resolved = resolve_interned_trace(trace, inplace=False)
 #include <retrobus/retrobus_perfetto.hpp>
 
 retrobus::PerfettoTraceBuilder builder("My Emulator");  // default: interned
-// retrobus::PerfettoTraceBuilder builder(
-//     "My Emulator",
-//     /*pid=*/1234,
-//     retrobus::PerfettoTraceBuilder::Encoding::Inline);  // opt out
+// C++ API always emits interned string fields.
 
 // Optional: resolve IID-backed names to inline strings for
 // string-based debugging/diff tooling.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ retrobus::PerfettoTraceBuilder builder("My Emulator");  // default: interned
 //     "My Emulator",
 //     /*pid=*/1234,
 //     retrobus::PerfettoTraceBuilder::Encoding::Inline);  // opt out
+
+// Optional: resolve IID-backed names to inline strings for
+// string-based debugging/diff tooling.
+perfetto::protos::Trace trace;
+trace.ParseFromString(builder.serialize());
+auto resolved = retrobus::resolve_interned_trace(trace); // returns a copy
+retrobus::resolve_interned_trace_inplace(trace);         // mutates in-place
 ```
 
 ## Documentation

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -141,12 +141,12 @@ int main() {
 ### PerfettoTraceBuilder
 
 Main builder class for creating traces.
+The C++ API emits interned string fields by default and only.
 
 ```cpp
 // Construction
 PerfettoTraceBuilder(std::string_view process_name,
-                     int32_t pid = 1234,
-                     Encoding encoding = Encoding::Interned);
+                     int32_t pid = 1234);
 
 // Track management
 uint64_t add_thread(std::string_view name);

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -144,7 +144,9 @@ Main builder class for creating traces.
 
 ```cpp
 // Construction
-PerfettoTraceBuilder(std::string_view process_name, int32_t pid = 1234);
+PerfettoTraceBuilder(std::string_view process_name,
+                     int32_t pid = 1234,
+                     Encoding encoding = Encoding::Interned);
 
 // Track management
 uint64_t add_thread(std::string_view name);
@@ -163,6 +165,10 @@ void update_counter(uint64_t track, double value, uint64_t timestamp_ns);
 // Output
 void save(const std::filesystem::path& path) const;
 std::vector<uint8_t> serialize() const;
+
+// Interned string helpers (for debug/diff tooling)
+void resolve_interned_trace_inplace(perfetto::protos::Trace& trace);
+perfetto::protos::Trace resolve_interned_trace(const perfetto::protos::Trace& trace);
 ```
 
 ### TrackEventWrapper

--- a/cpp/include/retrobus/retrobus_perfetto.hpp
+++ b/cpp/include/retrobus/retrobus_perfetto.hpp
@@ -124,6 +124,54 @@ namespace detail {
         uint64_t next_debug_annotation_name_iid_{1};
         uint64_t next_debug_annotation_string_value_iid_{1};
     };
+
+    struct SequenceInternTables {
+        std::unordered_map<uint64_t, std::string> event_names = {};
+        std::unordered_map<uint64_t, std::string> debug_annotation_names = {};
+        std::unordered_map<uint64_t, std::string> debug_annotation_string_values = {};
+        bool valid = false;
+
+        void clear(const bool mark_valid = false) {
+            event_names.clear();
+            debug_annotation_names.clear();
+            debug_annotation_string_values.clear();
+            valid = mark_valid;
+        }
+    };
+
+    inline std::string make_missing_iid_string(std::string_view kind, const uint64_t iid)
+    {
+        return "<missing " + std::string(kind) + " iid=" + std::to_string(iid) + ">";
+    }
+
+    inline void resolve_debug_annotation_inplace(perfetto::protos::DebugAnnotation& annotation,
+                                                 const SequenceInternTables& tables)
+    {
+        if (annotation.name_field_case() == perfetto::protos::DebugAnnotation::kNameIid) {
+            const auto iid = annotation.name_iid();
+            const auto it = tables.debug_annotation_names.find(iid);
+            annotation.set_name(it != tables.debug_annotation_names.end()
+                                        ? it->second
+                                        : make_missing_iid_string("DebugAnnotationName", iid));
+        }
+
+        if (annotation.value_case() ==
+            perfetto::protos::DebugAnnotation::kStringValueIid) {
+            const auto iid = annotation.string_value_iid();
+            const auto it = tables.debug_annotation_string_values.find(iid);
+            annotation.set_string_value(
+                    it != tables.debug_annotation_string_values.end()
+                            ? it->second
+                            : make_missing_iid_string("DebugAnnotationStringValue", iid));
+        }
+
+        for (auto& entry : *annotation.mutable_dict_entries()) {
+            resolve_debug_annotation_inplace(entry, tables);
+        }
+        for (auto& entry : *annotation.mutable_array_values()) {
+            resolve_debug_annotation_inplace(entry, tables);
+        }
+    }
 } // namespace detail
 
 // Main trace builder class
@@ -632,6 +680,71 @@ inline AnnotationBuilder TrackEventWrapper::annotation(std::string_view name) {
     }
     annotation->set_name(std::string(name));
     return AnnotationBuilder(annotation);
+}
+
+// Resolve interned IDs to inline strings in-place (for debugging/diff tooling).
+inline void resolve_interned_trace_inplace(perfetto::protos::Trace& trace)
+{
+    std::unordered_map<uint32_t, detail::SequenceInternTables> tables_by_sequence = {};
+
+    for (auto& packet : *trace.mutable_packet()) {
+        const auto sequence_id = packet.trusted_packet_sequence_id();
+        auto& tables = tables_by_sequence[sequence_id];
+
+        if (packet.previous_packet_dropped()) {
+            tables.clear(false);
+        }
+
+        const auto flags = packet.sequence_flags();
+        if ((flags & perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED) != 0) {
+            tables.clear(true);
+        }
+
+        if (packet.has_interned_data()) {
+            const auto& interned = packet.interned_data();
+            for (const auto& entry : interned.event_names()) {
+                tables.event_names[entry.iid()] = entry.name();
+            }
+            for (const auto& entry : interned.debug_annotation_names()) {
+                tables.debug_annotation_names[entry.iid()] = entry.name();
+            }
+            for (const auto& entry : interned.debug_annotation_string_values()) {
+                tables.debug_annotation_string_values[entry.iid()] = entry.str();
+            }
+        }
+
+        if (!packet.has_track_event()) {
+            continue;
+        }
+
+        const bool needs_state =
+                (flags & perfetto::protos::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE) != 0;
+        if (needs_state && !tables.valid) {
+            continue;
+        }
+
+        auto* event = packet.mutable_track_event();
+        if (event->name_field_case() == perfetto::protos::TrackEvent::kNameIid) {
+            const auto iid = event->name_iid();
+            const auto it = tables.event_names.find(iid);
+            event->set_name(it != tables.event_names.end()
+                                    ? it->second
+                                    : detail::make_missing_iid_string("EventName", iid));
+        }
+
+        for (auto& annotation : *event->mutable_debug_annotations()) {
+            detail::resolve_debug_annotation_inplace(annotation, tables);
+        }
+    }
+}
+
+// Return a copy with interned IDs resolved to inline strings.
+[[nodiscard]] inline perfetto::protos::Trace
+resolve_interned_trace(const perfetto::protos::Trace& trace)
+{
+    auto resolved = trace;
+    resolve_interned_trace_inplace(resolved);
+    return resolved;
 }
 
 } // namespace retrobus

--- a/cpp/include/retrobus/retrobus_perfetto.hpp
+++ b/cpp/include/retrobus/retrobus_perfetto.hpp
@@ -668,52 +668,61 @@ inline void resolve_interned_trace_inplace(perfetto::protos::Trace& trace)
     std::unordered_map<uint32_t, detail::SequenceInternTables> tables_by_sequence = {};
 
     for (auto& packet : *trace.mutable_packet()) {
-        const auto sequence_id = packet.trusted_packet_sequence_id();
-        auto& tables = tables_by_sequence[sequence_id];
-
-        if (packet.previous_packet_dropped()) {
-            tables.clear(false);
-        }
-
         const auto flags = packet.sequence_flags();
-        if ((flags & perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED) != 0) {
-            tables.clear(true);
-        }
+        detail::SequenceInternTables* tables = nullptr;
+        const bool has_valid_sequence_id = packet.has_trusted_packet_sequence_id() &&
+                                           packet.trusted_packet_sequence_id() != 0;
 
-        if (packet.has_interned_data()) {
-            const auto& interned = packet.interned_data();
-            for (const auto& entry : interned.event_names()) {
-                tables.event_names[entry.iid()] = entry.name();
+        if (has_valid_sequence_id) {
+            auto& sequence_tables = tables_by_sequence[packet.trusted_packet_sequence_id()];
+            tables = &sequence_tables;
+
+            if (packet.previous_packet_dropped()) {
+                tables->clear(false);
             }
-            for (const auto& entry : interned.debug_annotation_names()) {
-                tables.debug_annotation_names[entry.iid()] = entry.name();
+
+            if ((flags & perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED) != 0) {
+                tables->clear(true);
             }
-            for (const auto& entry : interned.debug_annotation_string_values()) {
-                tables.debug_annotation_string_values[entry.iid()] = entry.str();
+
+            if (packet.has_interned_data()) {
+                const auto& interned = packet.interned_data();
+                for (const auto& entry : interned.event_names()) {
+                    tables->event_names[entry.iid()] = entry.name();
+                }
+                for (const auto& entry : interned.debug_annotation_names()) {
+                    tables->debug_annotation_names[entry.iid()] = entry.name();
+                }
+                for (const auto& entry : interned.debug_annotation_string_values()) {
+                    tables->debug_annotation_string_values[entry.iid()] = entry.str();
+                }
             }
         }
 
         if (!packet.has_track_event()) {
             continue;
         }
+        if (!tables) {
+            continue;
+        }
 
         const bool needs_state =
                 (flags & perfetto::protos::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE) != 0;
-        if (needs_state && !tables.valid) {
+        if (needs_state && !tables->valid) {
             continue;
         }
 
         auto* event = packet.mutable_track_event();
         if (event->name_field_case() == perfetto::protos::TrackEvent::kNameIid) {
             const auto iid = event->name_iid();
-            const auto it = tables.event_names.find(iid);
-            event->set_name(it != tables.event_names.end()
+            const auto it = tables->event_names.find(iid);
+            event->set_name(it != tables->event_names.end()
                                     ? it->second
                                     : detail::make_missing_iid_string("EventName", iid));
         }
 
         for (auto& annotation : *event->mutable_debug_annotations()) {
-            detail::resolve_debug_annotation_inplace(annotation, tables);
+            detail::resolve_debug_annotation_inplace(annotation, *tables);
         }
     }
 }

--- a/cpp/include/retrobus/retrobus_perfetto.hpp
+++ b/cpp/include/retrobus/retrobus_perfetto.hpp
@@ -195,7 +195,7 @@ private:
     perfetto::protos::TracePacket* create_packet() {
         auto* packet = trace_->add_packet();
         packet->set_trusted_packet_sequence_id(trusted_packet_sequence_id_);
-        if (encoding_ == Encoding::Interned && !emitted_incremental_state_cleared_) {
+        if (!emitted_incremental_state_cleared_) {
             packet->set_sequence_flags(packet->sequence_flags() |
                                        perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED);
             emitted_incremental_state_cleared_ = true;
@@ -210,19 +210,12 @@ private:
     }
     
 public:
-    enum class Encoding {
-        Inline,
-        Interned,
-    };
-
     explicit PerfettoTraceBuilder(
         std::string_view process_name,
-        int32_t pid = detail::DEFAULT_PROCESS_PID,
-        Encoding encoding = Encoding::Interned)
+        int32_t pid = detail::DEFAULT_PROCESS_PID)
         : trace_(std::make_unique<perfetto::protos::Trace>())
         , process_uuid_(++last_track_uuid_)
-        , pid_(pid)
-        , encoding_(encoding) {
+        , pid_(pid) {
         
         // Add process descriptor
         auto* packet = create_packet();
@@ -374,7 +367,6 @@ public:
     }
 
 private:
-    Encoding encoding_{Encoding::Inline};
 };
 
 // Wrapper for track events to enable annotation chaining
@@ -626,13 +618,9 @@ inline TrackEventWrapper PerfettoTraceBuilder::begin_slice(uint64_t track_uuid, 
     auto* event = packet->mutable_track_event();
     event->set_type(perfetto::protos::TrackEvent::TYPE_SLICE_BEGIN);
     event->set_track_uuid(track_uuid);
-    if (encoding_ == Encoding::Interned) {
-        event->set_name_iid(interning_state_.intern_event_name(name, packet));
-    } else {
-        event->set_name(std::string(name));
-    }
+    event->set_name_iid(interning_state_.intern_event_name(name, packet));
     
-    return TrackEventWrapper(packet, event, encoding_ == Encoding::Interned ? &interning_state_ : nullptr);
+    return TrackEventWrapper(packet, event, &interning_state_);
 }
 
 inline TrackEventWrapper PerfettoTraceBuilder::add_instant_event(uint64_t track_uuid, std::string_view name, uint64_t timestamp_ns) {
@@ -641,13 +629,9 @@ inline TrackEventWrapper PerfettoTraceBuilder::add_instant_event(uint64_t track_
     auto* event = packet->mutable_track_event();
     event->set_type(perfetto::protos::TrackEvent::TYPE_INSTANT);
     event->set_track_uuid(track_uuid);
-    if (encoding_ == Encoding::Interned) {
-        event->set_name_iid(interning_state_.intern_event_name(name, packet));
-    } else {
-        event->set_name(std::string(name));
-    }
+    event->set_name_iid(interning_state_.intern_event_name(name, packet));
     
-    return TrackEventWrapper(packet, event, encoding_ == Encoding::Interned ? &interning_state_ : nullptr);
+    return TrackEventWrapper(packet, event, &interning_state_);
 }
 
 inline TrackEventWrapper PerfettoTraceBuilder::add_flow(uint64_t track_uuid, std::string_view name, uint64_t timestamp_ns,
@@ -657,11 +641,7 @@ inline TrackEventWrapper PerfettoTraceBuilder::add_flow(uint64_t track_uuid, std
     auto* event = packet->mutable_track_event();
     event->set_type(perfetto::protos::TrackEvent::TYPE_INSTANT);
     event->set_track_uuid(track_uuid);
-    if (encoding_ == Encoding::Interned) {
-        event->set_name_iid(interning_state_.intern_event_name(name, packet));
-    } else {
-        event->set_name(std::string(name));
-    }
+    event->set_name_iid(interning_state_.intern_event_name(name, packet));
     
     if (terminating) {
         event->add_terminating_flow_ids(flow_id);
@@ -669,7 +649,7 @@ inline TrackEventWrapper PerfettoTraceBuilder::add_flow(uint64_t track_uuid, std
         event->add_flow_ids(flow_id);
     }
     
-    return TrackEventWrapper(packet, event, encoding_ == Encoding::Interned ? &interning_state_ : nullptr);
+    return TrackEventWrapper(packet, event, &interning_state_);
 }
 
 inline AnnotationBuilder TrackEventWrapper::annotation(std::string_view name) {

--- a/cpp/tests/test_builder.cpp
+++ b/cpp/tests/test_builder.cpp
@@ -412,6 +412,41 @@ TEST_CASE("Resolve interned trace rewrites IID fields to strings", "[builder][in
     REQUIRE(saw_resolved_annotation_value);
 }
 
+TEST_CASE("Resolve interned trace ignores invalid packet sequence IDs", "[builder][interning]") {
+    perfetto::protos::Trace trace;
+
+    {
+        auto* packet = trace.add_packet();
+        packet->set_sequence_flags(perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED |
+                                   perfetto::protos::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+        auto* entry = packet->mutable_interned_data()->add_event_names();
+        entry->set_iid(1);
+        entry->set_name("alpha");
+    }
+    {
+        auto* packet = trace.add_packet();
+        packet->set_sequence_flags(perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED |
+                                   perfetto::protos::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+        auto* entry = packet->mutable_interned_data()->add_event_names();
+        entry->set_iid(1);
+        entry->set_name("beta");
+    }
+    {
+        auto* packet = trace.add_packet();
+        packet->set_sequence_flags(perfetto::protos::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE);
+        auto* event = packet->mutable_track_event();
+        event->set_type(perfetto::protos::TrackEvent::TYPE_INSTANT);
+        event->set_track_uuid(1);
+        event->set_name_iid(1);
+    }
+
+    resolve_interned_trace_inplace(trace);
+
+    const auto& event = trace.packet(2).track_event();
+    REQUIRE(event.name_field_case() == perfetto::protos::TrackEvent::kNameIid);
+    REQUIRE_FALSE(event.has_name());
+}
+
 TEST_CASE("Thread safety", "[builder][thread-safety]") {
     PerfettoTraceBuilder builder("TestProcess");
     

--- a/cpp/tests/test_builder.cpp
+++ b/cpp/tests/test_builder.cpp
@@ -280,6 +280,130 @@ TEST_CASE("Serialization", "[builder][serialization]") {
     }
 }
 
+TEST_CASE("Interned encoding uses IID-backed strings", "[builder][interning]") {
+    PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Interned);
+    const auto thread = builder.add_thread("TestThread");
+
+    // Repeated names/strings should be interned and reused.
+    builder.begin_slice(thread, "repeat_name", 1000)
+            .add_annotation("kind", "repeat_value")
+            .add_annotation("kind", "repeat_value");
+    builder.end_slice(thread, 2000);
+
+    builder.add_instant_event(thread, "repeat_name", 3000)
+            .add_annotation("kind", "repeat_value");
+
+    perfetto::protos::Trace trace;
+    const auto data = builder.serialize();
+    REQUIRE(trace.ParseFromArray(data.data(), static_cast<int>(data.size())));
+
+    bool saw_cleared_flag = false;
+    bool saw_needs_flag = false;
+    bool saw_event_name_intern = false;
+    bool saw_annotation_name_intern = false;
+    bool saw_annotation_string_intern = false;
+    bool saw_event_name_iid = false;
+    bool saw_annotation_name_iid = false;
+    bool saw_annotation_string_iid = false;
+
+    for (const auto& packet : trace.packet()) {
+        const auto flags = packet.sequence_flags();
+        if ((flags & perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED) != 0) {
+            saw_cleared_flag = true;
+        }
+        if ((flags & perfetto::protos::TracePacket::SEQ_NEEDS_INCREMENTAL_STATE) != 0) {
+            saw_needs_flag = true;
+        }
+
+        if (packet.has_interned_data()) {
+            for (const auto& name : packet.interned_data().event_names()) {
+                if (name.name() == "repeat_name") {
+                    saw_event_name_intern = true;
+                }
+            }
+            for (const auto& name : packet.interned_data().debug_annotation_names()) {
+                if (name.name() == "kind") {
+                    saw_annotation_name_intern = true;
+                }
+            }
+            for (const auto& value : packet.interned_data().debug_annotation_string_values()) {
+                if (value.str() == "repeat_value") {
+                    saw_annotation_string_intern = true;
+                }
+            }
+        }
+
+        if (!packet.has_track_event()) {
+            continue;
+        }
+        const auto& event = packet.track_event();
+        if (event.name_field_case() == perfetto::protos::TrackEvent::kNameIid) {
+            saw_event_name_iid = true;
+        }
+        for (const auto& ann : event.debug_annotations()) {
+            if (ann.name_field_case() == perfetto::protos::DebugAnnotation::kNameIid) {
+                saw_annotation_name_iid = true;
+            }
+            if (ann.value_case() ==
+                perfetto::protos::DebugAnnotation::kStringValueIid) {
+                saw_annotation_string_iid = true;
+            }
+        }
+    }
+
+    REQUIRE(saw_cleared_flag);
+    REQUIRE(saw_needs_flag);
+    REQUIRE(saw_event_name_intern);
+    REQUIRE(saw_annotation_name_intern);
+    REQUIRE(saw_annotation_string_intern);
+    REQUIRE(saw_event_name_iid);
+    REQUIRE(saw_annotation_name_iid);
+    REQUIRE(saw_annotation_string_iid);
+}
+
+TEST_CASE("Resolve interned trace rewrites IID fields to strings", "[builder][interning]") {
+    PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Interned);
+    const auto thread = builder.add_thread("TestThread");
+
+    builder.add_instant_event(thread, "resolve_me", 1000)
+            .add_annotation("key_name", "value_name");
+
+    perfetto::protos::Trace trace;
+    const auto data = builder.serialize();
+    REQUIRE(trace.ParseFromArray(data.data(), static_cast<int>(data.size())));
+
+    auto resolved = resolve_interned_trace(trace);
+
+    bool saw_resolved_event_name = false;
+    bool saw_resolved_annotation_name = false;
+    bool saw_resolved_annotation_value = false;
+
+    for (const auto& packet : resolved.packet()) {
+        if (!packet.has_track_event()) {
+            continue;
+        }
+        const auto& event = packet.track_event();
+        if (event.name_field_case() == perfetto::protos::TrackEvent::kName &&
+            event.name() == "resolve_me") {
+            saw_resolved_event_name = true;
+        }
+        for (const auto& ann : event.debug_annotations()) {
+            if (ann.name_field_case() == perfetto::protos::DebugAnnotation::kName &&
+                ann.name() == "key_name") {
+                saw_resolved_annotation_name = true;
+            }
+            if (ann.value_case() == perfetto::protos::DebugAnnotation::kStringValue &&
+                ann.string_value() == "value_name") {
+                saw_resolved_annotation_value = true;
+            }
+        }
+    }
+
+    REQUIRE(saw_resolved_event_name);
+    REQUIRE(saw_resolved_annotation_name);
+    REQUIRE(saw_resolved_annotation_value);
+}
+
 TEST_CASE("Thread safety", "[builder][thread-safety]") {
     PerfettoTraceBuilder builder("TestProcess");
     

--- a/cpp/tests/test_builder.cpp
+++ b/cpp/tests/test_builder.cpp
@@ -15,6 +15,14 @@ std::string to_textproto(const PerfettoTraceBuilder& builder) {
     if (!trace.ParseFromArray(data.data(), static_cast<int>(data.size()))) {
         return "ERROR: Failed to parse trace data";
     }
+
+    // Snapshot canonicalization: resolve interned IDs and remove
+    // sequence/interning metadata so snapshots stay semantically focused.
+    resolve_interned_trace_inplace(trace);
+    for (auto& packet : *trace.mutable_packet()) {
+        packet.clear_sequence_flags();
+        packet.clear_interned_data();
+    }
     
     std::string textproto;
     google::protobuf::TextFormat::PrintToString(trace, &textproto);
@@ -281,7 +289,7 @@ TEST_CASE("Serialization", "[builder][serialization]") {
 }
 
 TEST_CASE("Interned encoding uses IID-backed strings", "[builder][interning]") {
-    PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Interned);
+    PerfettoTraceBuilder builder("TestProcess", 1234);
     const auto thread = builder.add_thread("TestThread");
 
     // Repeated names/strings should be interned and reused.
@@ -362,7 +370,7 @@ TEST_CASE("Interned encoding uses IID-backed strings", "[builder][interning]") {
 }
 
 TEST_CASE("Resolve interned trace rewrites IID fields to strings", "[builder][interning]") {
-    PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Interned);
+    PerfettoTraceBuilder builder("TestProcess", 1234);
     const auto thread = builder.add_thread("TestThread");
 
     builder.add_instant_event(thread, "resolve_me", 1000)
@@ -424,7 +432,7 @@ TEST_CASE("Thread safety", "[builder][thread-safety]") {
 
 TEST_CASE("Textproto snapshot validation", "[builder][snapshot]") {
     SECTION("Empty trace") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         
         const char* expected = R"proto(packet {
   trusted_packet_sequence_id: 1
@@ -443,7 +451,7 @@ TEST_CASE("Textproto snapshot validation", "[builder][snapshot]") {
     }
     
     SECTION("Single thread") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread = builder.add_thread("TestThread");
         
         const char* expected = R"proto(packet {
@@ -475,7 +483,7 @@ packet {
     }
     
     SECTION("Basic slice event") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread = builder.add_thread("TestThread");
         
         builder.begin_slice(thread, "test_function", 1000);
@@ -527,7 +535,7 @@ packet {
     }
     
     SECTION("Instant event") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread = builder.add_thread("TestThread");
         
         builder.add_instant_event(thread, "checkpoint", 1500);
@@ -570,7 +578,7 @@ packet {
     }
     
     SECTION("Counter track and updates") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto counter = builder.add_counter_track("Memory", "MB");
         
         builder.update_counter(counter, 100, 1000);
@@ -619,7 +627,7 @@ packet {
     }
     
     SECTION("Slice with annotations") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread = builder.add_thread("TestThread");
         
         auto event = builder.begin_slice(thread, "test_function", 1000);
@@ -697,7 +705,7 @@ packet {
     }
     
     SECTION("Flow events") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread1 = builder.add_thread("Producer");
         auto thread2 = builder.add_thread("Consumer");
         
@@ -767,7 +775,7 @@ packet {
     }
     
     SECTION("Nested slices") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread = builder.add_thread("TestThread");
         
         builder.begin_slice(thread, "outer_function", 1000);
@@ -838,7 +846,7 @@ packet {
     }
     
     SECTION("Structured annotations") {
-        PerfettoTraceBuilder builder("TestProcess", 1234, PerfettoTraceBuilder::Encoding::Inline);
+        PerfettoTraceBuilder builder("TestProcess", 1234);
         auto thread = builder.add_thread("TestThread");
         
         auto event = builder.begin_slice(thread, "cpu_instruction", 1000);


### PR DESCRIPTION
## Summary
- add C++ helpers to resolve interned TrackEvent and DebugAnnotation string IDs into inline strings
- track interned state per trusted packet sequence and handle incremental state resets/drop flags
- add unit tests for IID-backed encoding and resolver behavior
- document resolver helpers in top-level and C++ READMEs

## Testing
- cmake -S cpp -B cpp/build
- cmake --build cpp/build -j8
- ctest --test-dir cpp/build --output-on-failure