### PR TITLE
Fix cross-track nesting in call graph

### DIFF
--- a/py/retrobus_perfetto/function_trace_summary.py
+++ b/py/retrobus_perfetto/function_trace_summary.py
@@ -231,7 +231,6 @@ def build_call_graph(
         track: str
 
     track_stacks: Dict[str, List[Frame]] = {}
-    active: List[Frame] = []
 
     for event in events:
         if include_filter and event.track not in include_filter:
@@ -239,11 +238,8 @@ def build_call_graph(
         if event.track in exclude_filter:
             continue
         if event.event_type == perfetto.TrackEvent.TYPE_SLICE_BEGIN:
-            if active:
-                parent_frame = max(active, key=lambda frame: frame.start_ts)
-                parent_node = parent_frame.node
-            else:
-                parent_node = root
+            stack = track_stacks.setdefault(event.track, [])
+            parent_node = stack[-1].node if stack else root
 
             resolved_name = event.name
             if name_map and event.track == "Functions":
@@ -270,13 +266,10 @@ def build_call_graph(
                 child.args[payload_key] = child.args.get(payload_key, 0) + 1
 
             frame = Frame(node=child, start_ts=event.timestamp, track=event.track)
-            track_stacks.setdefault(event.track, []).append(frame)
-            active.append(frame)
+            stack.append(frame)
         elif event.event_type == perfetto.TrackEvent.TYPE_SLICE_END:
             if track_stacks.get(event.track):
-                frame = track_stacks[event.track].pop()
-                if frame in active:
-                    active.remove(frame)
+                track_stacks[event.track].pop()
 
     return root
 

--- a/py/tests/test_function_trace_summary.py
+++ b/py/tests/test_function_trace_summary.py
@@ -106,3 +106,25 @@ def test_function_trace_summary(tmp_path: Path) -> None:
             to: 0x1010
 """
     assert summary == expected
+
+
+def test_multi_track_slices_do_not_cross_nest(tmp_path: Path) -> None:
+    trace_path = tmp_path / "multi-track.perfetto-trace"
+    builder = PerfettoTraceBuilder("TestProcess", encoding="interned")
+    functions = builder.add_thread("Functions")
+    opcodes = builder.add_thread("Opcodes")
+
+    builder.begin_slice(functions, "fn@0x1000", 10)
+    builder.begin_slice(opcodes, "NOP", 15)
+    builder.end_slice(opcodes, 16)
+    builder.end_slice(functions, 20)
+    trace_path.write_bytes(builder.serialize())
+
+    summary = summarize_trace_to_yaml(trace_path)
+    expected = """functions:
+  'Functions::fn@0x1000':
+    count: 1
+  'Opcodes::NOP':
+    count: 1
+"""
+    assert summary == expected


### PR DESCRIPTION
### Motivation
- Calling code used a global `active` frame list to find the parent for every `TYPE_SLICE_BEGIN`, which cross-links frames across tracks and can incorrectly nest slices from different tracks.
- Simplify and correct nesting semantics so each track's slices nest only within that track and avoid an O(n) parent lookup per begin event.

### Description
- Remove the global `active` list and derive the parent node from the per-track stack in `build_call_graph` by using `track_stacks[event.track]` and `stack[-1]` when present.
- Simplify slice begin/end handling to push/pop a single per-track `Frame` stack and avoid cross-track frame removal logic.
- Add a regression test `test_multi_track_slices_do_not_cross_nest` in `py/tests/test_function_trace_summary.py` to ensure interleaved slices on different tracks remain separate top-level nodes.
- Modified files: `py/retrobus_perfetto/function_trace_summary.py` and `py/tests/test_function_trace_summary.py`.

### Testing
- Ran `cd py && pytest tests/test_function_trace_summary.py` which initially failed due to missing protobuf dependency in the environment.
- Installed the runtime dependency with `pip install protobuf` and re-ran `pytest`.
- Result: `2 passed` for the targeted test file (`tests/test_function_trace_summary.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee6ee039883319015e0a31b2f2daa)