### PR TITLE
[codex] Intern nested debug annotation strings

### DIFF
--- a/cpp/include/retrobus/retrobus_perfetto.hpp
+++ b/cpp/include/retrobus/retrobus_perfetto.hpp
@@ -13,7 +13,6 @@
 #include <memory>
 #include <optional>
 #include <set>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -712,25 +711,13 @@ class AnnotationBuilder {
 private:
     friend class TrackEventWrapper;
     perfetto::protos::DebugAnnotation* annotation_;
-    perfetto::protos::DebugAnnotation::NestedValue* nested_;
     perfetto::protos::TracePacket* packet_;
     detail::InterningState* interning_state_;
 
-    static AnnotationBuilder for_nested(perfetto::protos::DebugAnnotation::NestedValue* nested,
-                                        perfetto::protos::TracePacket* packet,
-                                        detail::InterningState* interning_state) {
-        if (nested) {
-            nested->set_nested_type(perfetto::protos::DebugAnnotation::NestedValue::DICT);
-        }
-        return AnnotationBuilder(nullptr, nested, packet, interning_state);
-    }
-
     AnnotationBuilder(perfetto::protos::DebugAnnotation* annotation,
-                      perfetto::protos::DebugAnnotation::NestedValue* nested,
                       perfetto::protos::TracePacket* packet,
                       detail::InterningState* interning_state)
         : annotation_(annotation)
-        , nested_(nested)
         , packet_(packet)
         , interning_state_(interning_state) {}
 
@@ -747,24 +734,14 @@ private:
         return nullptr;
     }
 
-    perfetto::protos::DebugAnnotation::NestedValue* add_nested_entry(std::string_view key) {
-        if (nested_) {
-            nested_->add_dict_keys(std::string(key));
-            return nested_->add_dict_values();
-        }
-        return nullptr;
-    }
-
 public:
     explicit AnnotationBuilder(perfetto::protos::DebugAnnotation* annotation)
-        : AnnotationBuilder(annotation, nullptr, nullptr, nullptr) {}
+        : AnnotationBuilder(annotation, nullptr, nullptr) {}
 
     // Typed annotation methods
     AnnotationBuilder& integer(std::string_view key, int64_t value) {
         if (auto* entry = add_entry(key)) {
             entry->set_int_value(value);
-        } else if (auto* nested_val = add_nested_entry(key)) {
-            nested_val->set_int_value(value);
         }
         return *this;
     }
@@ -772,8 +749,6 @@ public:
     AnnotationBuilder& floating(std::string_view key, double value) {
         if (auto* entry = add_entry(key)) {
             entry->set_double_value(value);
-        } else if (auto* nested_val = add_nested_entry(key)) {
-            nested_val->set_double_value(value);
         }
         return *this;
     }
@@ -781,8 +756,6 @@ public:
     AnnotationBuilder& boolean(std::string_view key, bool value) {
         if (auto* entry = add_entry(key)) {
             entry->set_bool_value(value);
-        } else if (auto* nested_val = add_nested_entry(key)) {
-            nested_val->set_bool_value(value);
         }
         return *this;
     }
@@ -795,8 +768,6 @@ public:
             } else {
                 entry->set_string_value(std::string(value));
             }
-        } else if (auto* nested_val = add_nested_entry(key)) {
-            nested_val->set_string_value(std::string(value));
         }
         return *this;
     }
@@ -804,11 +775,6 @@ public:
     AnnotationBuilder& pointer(std::string_view key, uint64_t address) {
         if (auto* entry = add_entry(key)) {
             entry->set_pointer_value(address);
-        } else if (auto* nested_val = add_nested_entry(key)) {
-            // NestedValue does not support pointer_value, fall back to hex string
-            std::ostringstream oss;
-            oss << "0x" << std::hex << address;
-            nested_val->set_string_value(oss.str());
         }
         return *this;
     }
@@ -816,14 +782,9 @@ public:
     // Nested annotations - creates another level
     [[nodiscard]] AnnotationBuilder nested(std::string_view key) {
         if (auto* entry = add_entry(key)) {
-            auto* nested_val = entry->mutable_nested_value();
-            return for_nested(nested_val, packet_, interning_state_);
+            return AnnotationBuilder(entry, packet_, interning_state_);
         }
-        if (auto* nested_val = add_nested_entry(key)) {
-            nested_val->set_nested_type(perfetto::protos::DebugAnnotation::NestedValue::DICT);
-            return for_nested(nested_val, packet_, interning_state_);
-        }
-        return AnnotationBuilder(nullptr, nullptr, nullptr, nullptr);
+        return AnnotationBuilder(nullptr, nullptr, nullptr);
     }
 };
 
@@ -872,7 +833,7 @@ inline AnnotationBuilder TrackEventWrapper::annotation(std::string_view name) {
     auto* annotation = event_->add_debug_annotations();
     if (interning_state_) {
         annotation->set_name_iid(interning_state_->intern_debug_annotation_name(name, packet_));
-        return AnnotationBuilder(annotation, nullptr, packet_, interning_state_);
+        return AnnotationBuilder(annotation, packet_, interning_state_);
     }
     annotation->set_name(std::string(name));
     return AnnotationBuilder(annotation);

--- a/cpp/tests/test_builder.cpp
+++ b/cpp/tests/test_builder.cpp
@@ -30,6 +30,40 @@ std::string to_textproto(const PerfettoTraceBuilder& builder) {
     return textproto;
 }
 
+void require_annotation_uses_interned_strings(
+    const perfetto::protos::DebugAnnotation& annotation) {
+    REQUIRE(!annotation.has_name());
+    REQUIRE(annotation.name_field_case() !=
+            perfetto::protos::DebugAnnotation::kName);
+    REQUIRE(annotation.value_case() !=
+            perfetto::protos::DebugAnnotation::kStringValue);
+    REQUIRE(annotation.proto_type_descriptor_case() !=
+            perfetto::protos::DebugAnnotation::kProtoTypeName);
+    REQUIRE(!annotation.has_nested_value());
+    for (const auto& entry : annotation.dict_entries()) {
+        require_annotation_uses_interned_strings(entry);
+    }
+    for (const auto& entry : annotation.array_values()) {
+        require_annotation_uses_interned_strings(entry);
+    }
+}
+
+void require_track_events_use_interned_strings(
+    const perfetto::protos::Trace& trace) {
+    for (const auto& packet : trace.packet()) {
+        if (!packet.has_track_event()) {
+            continue;
+        }
+        const auto& event = packet.track_event();
+        REQUIRE(event.categories_size() == 0);
+        REQUIRE(!event.has_name());
+        REQUIRE(event.name_field_case() != perfetto::protos::TrackEvent::kName);
+        for (const auto& annotation : event.debug_annotations()) {
+            require_annotation_uses_interned_strings(annotation);
+        }
+    }
+}
+
 TEST_CASE("PerfettoTraceBuilder construction", "[builder]") {
     SECTION("Default constructor") {
         PerfettoTraceBuilder builder("TestProcess");
@@ -1145,6 +1179,7 @@ TEST_CASE("Interned encoding", "[builder][interning]") {
     perfetto::protos::Trace trace;
     auto data = builder.serialize();
     REQUIRE(trace.ParseFromArray(data.data(), static_cast<int>(data.size())));
+    require_track_events_use_interned_strings(trace);
 
     const auto& seq_start_packet = trace.packet(0);
     REQUIRE((seq_start_packet.sequence_flags() & perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED) != 0);
@@ -1194,4 +1229,41 @@ TEST_CASE("Interned encoding", "[builder][interning]") {
     REQUIRE((second_packet.sequence_flags() & perfetto::protos::TracePacket::SEQ_INCREMENTAL_STATE_CLEARED) == 0);
     REQUIRE(second_packet.track_event().name_iid() == first_packet.track_event().name_iid());
     REQUIRE(!second_packet.has_interned_data());
+}
+
+TEST_CASE("Interned encoding covers nested annotations", "[builder][interning]") {
+    PerfettoTraceBuilder builder("TestProcess", 1234);
+    auto thread = builder.add_thread("TestThread");
+
+    auto event = builder.add_instant_event(thread, "nested_event", 1500);
+    event.annotation("root")
+        .string("label", "top")
+        .nested("child")
+        .string("name", "leaf")
+        .integer("count", 2);
+
+    perfetto::protos::Trace trace;
+    auto data = builder.serialize();
+    REQUIRE(trace.ParseFromArray(data.data(), static_cast<int>(data.size())));
+
+    require_track_events_use_interned_strings(trace);
+
+    const auto& packet = trace.packet(2);
+    REQUIRE(packet.has_track_event());
+    REQUIRE(packet.track_event().debug_annotations_size() == 1);
+    const auto& root = packet.track_event().debug_annotations(0);
+    REQUIRE(root.has_name_iid());
+    REQUIRE(root.dict_entries_size() == 2);
+
+    const auto& label = root.dict_entries(0);
+    REQUIRE(label.has_name_iid());
+    REQUIRE(label.has_string_value_iid());
+
+    const auto& child = root.dict_entries(1);
+    REQUIRE(child.has_name_iid());
+    REQUIRE(child.dict_entries_size() == 2);
+    REQUIRE(child.dict_entries(0).has_name_iid());
+    REQUIRE(child.dict_entries(0).has_string_value_iid());
+    REQUIRE(child.dict_entries(1).has_name_iid());
+    REQUIRE(child.dict_entries(1).int_value() == 2);
 }


### PR DESCRIPTION
## Summary

- Replace the C++ nested annotation builder's legacy `DebugAnnotation::NestedValue` path with recursive `DebugAnnotation::dict_entries`.
- Keep nested annotation names and string values on the same interned `name_iid` / `string_value_iid` path as top-level annotations.
- Add tests that reject inline `TrackEvent` names, annotation names, annotation string values, proto type names, categories, and legacy nested values where interned fields exist.

## Why

`NestedValue` stores dictionary keys and string values as inline strings, so nested annotations were the remaining C++ builder path that violated the "all internable TrackEvent strings are interned" invariant. Recursive `dict_entries` preserves the same annotation structure while using Perfetto's supported interned fields.

## Validation

```bash
cmake --build cpp/build --target test_retrobus_perfetto -j 8
cpp/build/tests/test_retrobus_perfetto
```

All tests passed: 178 assertions in 16 test cases.